### PR TITLE
Wrap Throwables in ExecutionException

### DIFF
--- a/src/main/java/org/zalando/switchboard/Answer.java
+++ b/src/main/java/org/zalando/switchboard/Answer.java
@@ -51,7 +51,7 @@ final class Answer<T, R, H> implements Future<R>, Predicate<Object> {
     private final AtomicReference<State> state = new AtomicReference<>(State.WAITING);
 
     private final Subscription<T, H> subscription;
-    private final SubscriptionMode<T, R, ?> mode;
+    private final SubscriptionMode<T, R> mode;
     private final Consumer<Answer<T, R, H>> unregister;
 
     private final BlockingQueue<Deliverable<T>> queue = new LinkedBlockingQueue<>();
@@ -59,7 +59,7 @@ final class Answer<T, R, H> implements Future<R>, Predicate<Object> {
 
     private final LockSupport lock = new LockSupport();
 
-    Answer(final Subscription<T, H> subscription, final SubscriptionMode<T, R, ?> mode, final Consumer<Answer<T, R, H>> unregister) {
+    Answer(final Subscription<T, H> subscription, final SubscriptionMode<T, R> mode, final Consumer<Answer<T, R, H>> unregister) {
         this.subscription = subscription;
         this.mode = mode;
         this.unregister = unregister;
@@ -182,11 +182,7 @@ final class Answer<T, R, H> implements Future<R>, Predicate<Object> {
     }
 
     private void deliver(final List<T> results, final Deliverable<T> deliverable) throws ExecutionException {
-        try {
-            deliverable.deliverTo(results);
-        } catch (final RuntimeException e) {
-            throw new ExecutionException(e);
-        }
+        deliverable.deliverTo(results);
     }
 
     private R verifyAndTransform(final List<T> results, final int received, final Function<Integer, String> message) {

--- a/src/main/java/org/zalando/switchboard/AtLeast.java
+++ b/src/main/java/org/zalando/switchboard/AtLeast.java
@@ -26,7 +26,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-final class AtLeast<S> implements SubscriptionMode<S, List<S>, TimeoutException> {
+final class AtLeast<S> implements SubscriptionMode<S, List<S>> {
 
     private final int count;
 

--- a/src/main/java/org/zalando/switchboard/AtLeastOnce.java
+++ b/src/main/java/org/zalando/switchboard/AtLeastOnce.java
@@ -26,7 +26,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-final class AtLeastOnce<S> implements SubscriptionMode<S, S, TimeoutException> {
+final class AtLeastOnce<S> implements SubscriptionMode<S, S> {
 
     @Override
     public S block(final Future<S> future, final long timeout, final TimeUnit timeoutUnit) throws InterruptedException, ExecutionException, TimeoutException {

--- a/src/main/java/org/zalando/switchboard/AtMost.java
+++ b/src/main/java/org/zalando/switchboard/AtMost.java
@@ -26,7 +26,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-final class AtMost<S> implements SubscriptionMode<S, List<S>, RuntimeException> {
+final class AtMost<S> implements SubscriptionMode<S, List<S>> {
 
     private final int count;
 
@@ -36,12 +36,8 @@ final class AtMost<S> implements SubscriptionMode<S, List<S>, RuntimeException> 
 
     @Override
     public List<S> block(final Future<List<S>> future, final long timeout, final TimeUnit timeoutUnit)
-            throws RuntimeException, InterruptedException, ExecutionException {
-        try {
-            return future.get(timeout, timeoutUnit);
-        } catch (final TimeoutException ignored) {
-            return null;
-        }
+            throws ExecutionException, InterruptedException, TimeoutException {
+        return future.get(timeout, timeoutUnit);
     }
 
     @Override

--- a/src/main/java/org/zalando/switchboard/Deliverable.java
+++ b/src/main/java/org/zalando/switchboard/Deliverable.java
@@ -21,6 +21,7 @@ package org.zalando.switchboard;
  */
 
 import java.util.Collection;
+import java.util.concurrent.ExecutionException;
 
 public interface Deliverable<T> {
 
@@ -30,7 +31,7 @@ public interface Deliverable<T> {
      * @param target target collection, potentially being passed to the receiver
      * @throws RuntimeException if delivery should fail
      */
-    void deliverTo(Collection<? super T> target) throws RuntimeException;
+    void deliverTo(Collection<? super T> target) throws ExecutionException;
 
     T getMessage();
 
@@ -40,8 +41,8 @@ public interface Deliverable<T> {
         return new Message<>(message, mode);
     }
 
-    static <T> Deliverable<T> failure(final T message, final DeliveryMode mode, final RuntimeException exception) {
-        return new Failure<>(message, mode, exception);
+    static <T> Deliverable<T> failure(final T message, final DeliveryMode mode, final Throwable throwable) {
+        return new Failure<>(message, mode, throwable);
     }
 
 }

--- a/src/main/java/org/zalando/switchboard/ExactlyOnce.java
+++ b/src/main/java/org/zalando/switchboard/ExactlyOnce.java
@@ -26,7 +26,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-final class ExactlyOnce<S> implements SubscriptionMode<S, S, TimeoutException> {
+final class ExactlyOnce<S> implements SubscriptionMode<S, S> {
 
     @Override
     public boolean requiresTimeout() {

--- a/src/main/java/org/zalando/switchboard/Failure.java
+++ b/src/main/java/org/zalando/switchboard/Failure.java
@@ -21,22 +21,23 @@ package org.zalando.switchboard;
  */
 
 import java.util.Collection;
+import java.util.concurrent.ExecutionException;
 
 final class Failure<T> implements Deliverable<T> {
 
     private final T message;
     private final DeliveryMode deliveryMode;
-    private final RuntimeException exception;
+    private final Throwable throwable;
 
-    Failure(final T message, final DeliveryMode deliveryMode, final RuntimeException exception) {
+    Failure(final T message, final DeliveryMode deliveryMode, final Throwable throwable) {
         this.message = message;
         this.deliveryMode = deliveryMode;
-        this.exception = exception;
+        this.throwable = throwable;
     }
 
     @Override
-    public void deliverTo(final Collection<? super T> target) {
-        throw exception;
+    public void deliverTo(final Collection<? super T> target) throws ExecutionException {
+        throw new ExecutionException(throwable);
     }
 
     @Override

--- a/src/main/java/org/zalando/switchboard/Never.java
+++ b/src/main/java/org/zalando/switchboard/Never.java
@@ -26,11 +26,11 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-final class Never<S> implements SubscriptionMode<S, Void, RuntimeException> {
+final class Never<S> implements SubscriptionMode<S, Void> {
 
     @Override
     public Void block(final Future<Void> future, final long timeout, final TimeUnit timeoutUnit)
-            throws RuntimeException, InterruptedException, ExecutionException {
+            throws InterruptedException, ExecutionException {
         try {
             return future.get(timeout, timeoutUnit);
         } catch (final TimeoutException ignored) {

--- a/src/main/java/org/zalando/switchboard/SubscriptionMode.java
+++ b/src/main/java/org/zalando/switchboard/SubscriptionMode.java
@@ -26,13 +26,13 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-public interface SubscriptionMode<T, R, X extends Exception> {
+public interface SubscriptionMode<T, R> {
 
     default boolean requiresTimeout() {
         return false;
     }
 
-    R block(final Future<R> future, final long timeout, final TimeUnit timeoutUnit) throws X, ExecutionException, InterruptedException;
+    R block(final Future<R> future, final long timeout, final TimeUnit timeoutUnit) throws ExecutionException, TimeoutException, InterruptedException;
 
     boolean isDone(int received);
 
@@ -41,32 +41,32 @@ public interface SubscriptionMode<T, R, X extends Exception> {
     R collect(List<T> results);
 
     // TODO non blocking, at most until end of timeout
-    static <S> SubscriptionMode<S, Void, RuntimeException> never() {
+    static <S> SubscriptionMode<S, Void> never() {
         return new Never<>();
     }
 
     // TODO non blocking, at most until end of timeout
-    static <S> SubscriptionMode<S, List<S>, RuntimeException> atMost(final int count) {
+    static <S> SubscriptionMode<S, List<S>> atMost(final int count) {
         return new AtMost<>(count);
     }
 
     // TODO exactly, blocking
-    static <S> SubscriptionMode<S, S, TimeoutException> exactlyOnce() {
+    static <S> SubscriptionMode<S, S> exactlyOnce() {
         return new ExactlyOnce<>();
     }
 
     // TODO exactly, blocking
-    static <S> SubscriptionMode<S, List<S>, TimeoutException> times(final int count) {
+    static <S> SubscriptionMode<S, List<S>> times(final int count) {
         return new Times<>(count);
     }
 
     // TODO non blocking, at most until end of timeout
-    static <S> SubscriptionMode<S, S, TimeoutException> atLeastOnce() {
+    static <S> SubscriptionMode<S, S> atLeastOnce() {
         return new AtLeastOnce<>();
     }
 
     // TODO non blocking, at most until end of timeout
-    static <S> SubscriptionMode<S, List<S>, TimeoutException> atLeast(final int count) {
+    static <S> SubscriptionMode<S, List<S>> atLeast(final int count) {
         return new AtLeast<>(count);
     }
 

--- a/src/main/java/org/zalando/switchboard/Switchboard.java
+++ b/src/main/java/org/zalando/switchboard/Switchboard.java
@@ -22,7 +22,9 @@ package org.zalando.switchboard;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
 
 /**
  * publish/subscribe, async, hand-over/broadcast
@@ -30,12 +32,13 @@ import java.util.concurrent.Future;
  */
 public interface Switchboard {
 
-    <T, R, X extends Exception> R receive(final Subscription<T, ?> subscription, final SubscriptionMode<T, R, X> mode, final Duration timeout)
-            throws X, InterruptedException;
 
-    <T, R, X extends Exception> Future<R> subscribe(final Subscription<T, ?> subscription, final SubscriptionMode<T, R, X> mode);
+    <T, R> R receive(final Subscription<T, ?> subscription, final SubscriptionMode<T, R> mode, final Duration timeout)
+            throws ExecutionException, TimeoutException, InterruptedException;
 
-    <T, H> List<H> inspect(Class<T> messageType, Class<H> hintType);
+    <T, R> Future<R> subscribe(final Subscription<T, ?> subscription, final SubscriptionMode<T, R> mode);
+
+    <T, H> List<H> inspect(final Class<T> messageType, final Class<H> hintType);
 
     <T> void send(final Deliverable<T> deliverable);
 

--- a/src/main/java/org/zalando/switchboard/Times.java
+++ b/src/main/java/org/zalando/switchboard/Times.java
@@ -26,7 +26,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-public class Times<S> implements SubscriptionMode<S, List<S>, TimeoutException> {
+public class Times<S> implements SubscriptionMode<S, List<S>> {
 
     private final int count;
 

--- a/src/test/java/org/zalando/switchboard/EnforceCoverageTest.java
+++ b/src/test/java/org/zalando/switchboard/EnforceCoverageTest.java
@@ -50,16 +50,6 @@ public final class EnforceCoverageTest {
     }
 
     @Test
-    public void shouldVisitDeadCatchClauseInAtMost() throws ExecutionException, TimeoutException, InterruptedException {
-        @SuppressWarnings("unchecked")
-        final Future<List<String>> future = mock(Future.class);
-        when(future.get(anyLong(), any())).thenThrow(new TimeoutException());
-
-        final AtMost<String> mode = new AtMost<>(1);
-        mode.block(future, 1, TimeUnit.NANOSECONDS);
-    }
-
-    @Test
     public void shouldVisitDeadCatchClauseInNever() throws ExecutionException, TimeoutException, InterruptedException {
         @SuppressWarnings("unchecked")
         final Future<Void> future = mock(Future.class);

--- a/src/test/java/org/zalando/switchboard/SubscriptionTest.java
+++ b/src/test/java/org/zalando/switchboard/SubscriptionTest.java
@@ -25,6 +25,7 @@ import org.junit.gen5.api.Test;
 import javax.annotation.concurrent.Immutable;
 import java.math.BigDecimal;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 import static java.time.temporal.ChronoUnit.NANOS;
@@ -56,7 +57,7 @@ public final class SubscriptionTest {
     }
 
     @Test
-    public void shouldSupportLambdas() throws TimeoutException, InterruptedException {
+    public void shouldSupportLambdas() throws TimeoutException, InterruptedException, ExecutionException {
         unit.send(message("foo", directly()));
         final Subscription<String, ?> subscription = (String e) -> true;
         final String actual = unit.receive(subscription, exactlyOnce(), within(1, NANOS));
@@ -64,14 +65,14 @@ public final class SubscriptionTest {
     }
 
     @Test
-    public void shouldSupportMethodReference() throws TimeoutException, InterruptedException {
+    public void shouldSupportMethodReference() throws TimeoutException, InterruptedException, ExecutionException {
         unit.send(message("foo", directly()));
         final String actual = unit.receive(this::anyString, exactlyOnce(), within(1, NANOS));
         assertThat(actual, is("foo"));
     }
 
     @Test
-    public void shouldSupportInstanceMethodReference() throws TimeoutException, InterruptedException {
+    public void shouldSupportInstanceMethodReference() throws TimeoutException, InterruptedException, ExecutionException {
         unit.send(message("foo", directly()));
         final String actual = unit.receive("foo"::equals, exactlyOnce(), within(1, NANOS));
         assertThat(actual, is("foo"));
@@ -101,7 +102,7 @@ public final class SubscriptionTest {
     }
 
     @Test
-    public void shouldDelegateToPredicate() throws TimeoutException, InterruptedException {
+    public void shouldDelegateToPredicate() throws TimeoutException, InterruptedException, ExecutionException {
         final Subscription<String, Object> subscription = on(String.class, "foo"::equals);
 
         unit.send(message("foo", broadcast()));
@@ -111,7 +112,7 @@ public final class SubscriptionTest {
     }
 
     @Test
-    public void shouldNotMatchDifferentType() throws TimeoutException, InterruptedException {
+    public void shouldNotMatchDifferentType() {
         unit.send(message(123, broadcast()));
 
         expectThrows(TimeoutException.class, () -> {

--- a/src/test/java/org/zalando/switchboard/contracts/AtLeastContract.java
+++ b/src/test/java/org/zalando/switchboard/contracts/AtLeastContract.java
@@ -25,6 +25,7 @@ import org.zalando.switchboard.Switchboard;
 import org.zalando.switchboard.traits.DeliveryTrait;
 import org.zalando.switchboard.traits.SubscriptionTrait;
 
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 import static java.time.temporal.ChronoUnit.NANOS;
@@ -38,7 +39,7 @@ import static org.zalando.switchboard.Timeout.within;
 public interface AtLeastContract<S> extends SubscriptionTrait<S>, DeliveryTrait {
 
     @Test
-    default void shouldFailIfExpectedAtLeastThreeButReceivedOnlyTwo() throws TimeoutException, InterruptedException {
+    default void shouldFailIfExpectedAtLeastThreeButReceivedOnlyTwo() {
         final Switchboard unit = Switchboard.create();
 
         unit.send(message("foo", deliveryMode()));
@@ -52,7 +53,7 @@ public interface AtLeastContract<S> extends SubscriptionTrait<S>, DeliveryTrait 
     }
 
     @Test
-    default void shouldNotFailIfExpectedAtLeastThreeAndReceivedExactlyThree() throws TimeoutException, InterruptedException {
+    default void shouldNotFailIfExpectedAtLeastThreeAndReceivedExactlyThree() throws TimeoutException, InterruptedException, ExecutionException {
         final Switchboard unit = Switchboard.create();
 
         unit.send(message("foo", deliveryMode()));
@@ -63,7 +64,7 @@ public interface AtLeastContract<S> extends SubscriptionTrait<S>, DeliveryTrait 
     }
 
     @Test
-    default void shouldNotFailIfExpectedAtLeastThreeAndReceivedFour() throws TimeoutException, InterruptedException {
+    default void shouldNotFailIfExpectedAtLeastThreeAndReceivedFour() throws TimeoutException, InterruptedException, ExecutionException {
         final Switchboard unit = Switchboard.create();
 
         unit.send(message("foo", deliveryMode()));

--- a/src/test/java/org/zalando/switchboard/contracts/AtLeastOnceContract.java
+++ b/src/test/java/org/zalando/switchboard/contracts/AtLeastOnceContract.java
@@ -25,6 +25,7 @@ import org.zalando.switchboard.Switchboard;
 import org.zalando.switchboard.traits.DeliveryTrait;
 import org.zalando.switchboard.traits.SubscriptionTrait;
 
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 import static java.time.temporal.ChronoUnit.NANOS;
@@ -38,7 +39,7 @@ import static org.zalando.switchboard.Timeout.within;
 public interface AtLeastOnceContract<S> extends SubscriptionTrait<S>, DeliveryTrait {
 
     @Test
-    default void shouldFailIfExpectedAtLeastOneButReceivedNone() throws TimeoutException, InterruptedException {
+    default void shouldFailIfExpectedAtLeastOneButReceivedNone() {
         final Switchboard unit = Switchboard.create();
 
         final TimeoutException exception = expectThrows(TimeoutException.class, () -> {
@@ -49,7 +50,7 @@ public interface AtLeastOnceContract<S> extends SubscriptionTrait<S>, DeliveryTr
     }
 
     @Test
-    default void shouldNotFailIfExpectedAtLeastOneAndReceivedExactlyOne() throws TimeoutException, InterruptedException {
+    default void shouldNotFailIfExpectedAtLeastOneAndReceivedExactlyOne() throws TimeoutException, InterruptedException, ExecutionException {
         final Switchboard unit = Switchboard.create();
 
         unit.send(message("foo", deliveryMode()));
@@ -58,7 +59,7 @@ public interface AtLeastOnceContract<S> extends SubscriptionTrait<S>, DeliveryTr
     }
 
     @Test
-    default void shouldNotFailIfExpectedAtLeastOneAndReceivedTwo() throws TimeoutException, InterruptedException {
+    default void shouldNotFailIfExpectedAtLeastOneAndReceivedTwo() throws TimeoutException, InterruptedException, ExecutionException {
         final Switchboard unit = Switchboard.create();
 
         unit.send(message("foo", deliveryMode()));

--- a/src/test/java/org/zalando/switchboard/contracts/AtMostContract.java
+++ b/src/test/java/org/zalando/switchboard/contracts/AtMostContract.java
@@ -26,6 +26,7 @@ import org.zalando.switchboard.traits.DeliveryTrait;
 import org.zalando.switchboard.traits.SubscriptionTrait;
 
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 
 import static java.time.temporal.ChronoUnit.NANOS;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -38,7 +39,7 @@ import static org.zalando.switchboard.Timeout.within;
 public interface AtMostContract<S> extends SubscriptionTrait<S>, DeliveryTrait {
 
     @Test
-    default void shouldNotFailIfExpectedAtMostThreeButReceivedOnlyTwo() throws InterruptedException {
+    default void shouldNotFailIfExpectedAtMostThreeButReceivedOnlyTwo() throws InterruptedException, TimeoutException, ExecutionException {
         final Switchboard unit = Switchboard.create();
 
         unit.send(message("foo", deliveryMode()));
@@ -48,7 +49,7 @@ public interface AtMostContract<S> extends SubscriptionTrait<S>, DeliveryTrait {
     }
 
     @Test
-    default void shouldNotFailIfExpectedAtMostThreeAndReceivedExactlyThree() throws InterruptedException {
+    default void shouldNotFailIfExpectedAtMostThreeAndReceivedExactlyThree() throws InterruptedException, TimeoutException, ExecutionException {
         final Switchboard unit = Switchboard.create();
 
         unit.send(message("foo", deliveryMode()));
@@ -59,7 +60,7 @@ public interface AtMostContract<S> extends SubscriptionTrait<S>, DeliveryTrait {
     }
 
     @Test
-    default void shouldFailIfExpectedAtMostThreeButReceivedFourWithTimeout() throws InterruptedException {
+    default void shouldFailIfExpectedAtMostThreeButReceivedFourWithTimeout() {
         final Switchboard unit = Switchboard.create();
 
         unit.send(message("foo", deliveryMode()));
@@ -75,7 +76,7 @@ public interface AtMostContract<S> extends SubscriptionTrait<S>, DeliveryTrait {
     }
 
     @Test
-    default void shouldFailIfExpectedAtMostThreeButReceivedFourWithout() throws ExecutionException, InterruptedException {
+    default void shouldFailIfExpectedAtMostThreeButReceivedFourWithout() {
         final Switchboard unit = Switchboard.create();
 
         unit.send(message("foo", deliveryMode()));

--- a/src/test/java/org/zalando/switchboard/contracts/ExactlyOnceContract.java
+++ b/src/test/java/org/zalando/switchboard/contracts/ExactlyOnceContract.java
@@ -50,7 +50,7 @@ public interface ExactlyOnceContract<S> extends SubscriptionTrait<S>, DeliveryTr
     }
 
     @Test
-    default void shouldFailIfExpectedOneButReceivedNone() throws TimeoutException, InterruptedException {
+    default void shouldFailIfExpectedOneButReceivedNone() {
         final Switchboard unit = Switchboard.create();
 
         final TimeoutException exception = expectThrows(TimeoutException.class, () -> {
@@ -61,7 +61,7 @@ public interface ExactlyOnceContract<S> extends SubscriptionTrait<S>, DeliveryTr
     }
 
     @Test
-    default void shouldNotFailIfExpectedOneAndReceivedExactlyOne() throws TimeoutException, InterruptedException {
+    default void shouldNotFailIfExpectedOneAndReceivedExactlyOne() throws TimeoutException, InterruptedException, ExecutionException {
         final Switchboard unit = Switchboard.create();
 
         unit.send(message("foo", deliveryMode()));
@@ -70,7 +70,7 @@ public interface ExactlyOnceContract<S> extends SubscriptionTrait<S>, DeliveryTr
     }
 
     @Test
-    default void shouldFailIfExpectedOneButReceivedTwo() throws TimeoutException, InterruptedException {
+    default void shouldFailIfExpectedOneButReceivedTwo() {
         final Switchboard unit = Switchboard.create();
 
         unit.send(message("foo", deliveryMode()));

--- a/src/test/java/org/zalando/switchboard/contracts/NeverContract.java
+++ b/src/test/java/org/zalando/switchboard/contracts/NeverContract.java
@@ -26,6 +26,7 @@ import org.zalando.switchboard.traits.DeliveryTrait;
 import org.zalando.switchboard.traits.SubscriptionTrait;
 
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 
 import static java.time.temporal.ChronoUnit.NANOS;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -38,14 +39,14 @@ import static org.zalando.switchboard.Timeout.within;
 public interface NeverContract<S> extends SubscriptionTrait<S>, DeliveryTrait {
 
     @Test
-    default void shouldNotFailIfExpectedNoneAndReceivedNone() throws InterruptedException {
+    default void shouldNotFailIfExpectedNoneAndReceivedNone() throws InterruptedException, TimeoutException, ExecutionException {
         final Switchboard unit = Switchboard.create();
 
         unit.receive("foo"::equals, never(), within(1, NANOS));
     }
 
     @Test
-    default void shouldFailIfExpectedNoneButReceivedOneWithTimeout() throws InterruptedException {
+    default void shouldFailIfExpectedNoneButReceivedOneWithTimeout() {
         final Switchboard unit = Switchboard.create();
 
         unit.send(message("foo", deliveryMode()));
@@ -58,7 +59,7 @@ public interface NeverContract<S> extends SubscriptionTrait<S>, DeliveryTrait {
     }
 
     @Test
-    default void shouldFailIfExpectedNoneButReceivedOneWithoutTimeout() throws ExecutionException, InterruptedException {
+    default void shouldFailIfExpectedNoneButReceivedOneWithoutTimeout() {
         final Switchboard unit = Switchboard.create();
 
         unit.send(message("foo", deliveryMode()));

--- a/src/test/java/org/zalando/switchboard/contracts/SubscribeContract.java
+++ b/src/test/java/org/zalando/switchboard/contracts/SubscribeContract.java
@@ -77,7 +77,7 @@ public interface SubscribeContract<S> extends SubscriptionTrait<S>, DeliveryTrai
     }
 
     @Test // TODO (timeout = TestTimeout.DEFAULT)
-    default void shouldTimeoutWhenThereAreNoMatchingMessages() throws TimeoutException, InterruptedException {
+    default void shouldTimeoutWhenThereAreNoMatchingMessages() {
         final Switchboard unit = Switchboard.create();
 
         unit.send(message(messageA(), deliveryMode()));
@@ -89,7 +89,7 @@ public interface SubscribeContract<S> extends SubscriptionTrait<S>, DeliveryTrai
     }
 
     @Test // TODO (timeout = TestTimeout.DEFAULT)
-    default void shouldPollMultipleTimesWhenCountGiven() throws TimeoutException, InterruptedException {
+    default void shouldPollMultipleTimesWhenCountGiven() throws TimeoutException, InterruptedException, ExecutionException {
         final Switchboard unit = Switchboard.create();
         
         final int count = 5;

--- a/src/test/java/org/zalando/switchboard/contracts/TimeoutContract.java
+++ b/src/test/java/org/zalando/switchboard/contracts/TimeoutContract.java
@@ -40,7 +40,7 @@ import static org.zalando.switchboard.Timeout.within;
 public interface TimeoutContract<S> extends SubscriptionTrait<S>, DeliveryTrait {
 
     @Test // TODO (timeout = TestTimeout.DEFAULT)
-    default void shouldTellThatThirdMessageDidNotOccur() throws TimeoutException, InterruptedException {
+    default void shouldTellThatThirdMessageDidNotOccur() {
         final Switchboard unit = Switchboard.create();
 
         unit.send(message(messageA(), deliveryMode()));
@@ -54,7 +54,7 @@ public interface TimeoutContract<S> extends SubscriptionTrait<S>, DeliveryTrait 
     }
 
     @Test // TODO (timeout = TestTimeout.DEFAULT)
-    default void shouldTellThatThirdMessageDidNotOccurWhenPollingAsync() throws TimeoutException, ExecutionException, InterruptedException {
+    default void shouldTellThatThirdMessageDidNotOccurWhenPollingAsync() {
         final Switchboard unit = Switchboard.create();
 
         unit.send(message(messageA(), deliveryMode()));

--- a/src/test/java/org/zalando/switchboard/contracts/TimesContract.java
+++ b/src/test/java/org/zalando/switchboard/contracts/TimesContract.java
@@ -50,7 +50,7 @@ public interface TimesContract<S> extends SubscriptionTrait<S>, DeliveryTrait {
     }
 
     @Test
-    default void shouldFailIfExpectedThreeButReceivedOnlyTwo() throws TimeoutException, InterruptedException {
+    default void shouldFailIfExpectedThreeButReceivedOnlyTwo() {
         final Switchboard unit = Switchboard.create();
 
         unit.send(message("foo", deliveryMode()));
@@ -64,7 +64,7 @@ public interface TimesContract<S> extends SubscriptionTrait<S>, DeliveryTrait {
     }
 
     @Test
-    default void shouldNotFailIfExpectedThreeAndReceivedExactlyThree() throws TimeoutException, InterruptedException {
+    default void shouldNotFailIfExpectedThreeAndReceivedExactlyThree() throws TimeoutException, InterruptedException, ExecutionException {
         final Switchboard unit = Switchboard.create();
 
         unit.send(message("foo", deliveryMode()));
@@ -75,7 +75,7 @@ public interface TimesContract<S> extends SubscriptionTrait<S>, DeliveryTrait {
     }
 
     @Test
-    default void shouldFailIfExpectedThreeButReceivedFour() throws TimeoutException, InterruptedException {
+    default void shouldFailIfExpectedThreeButReceivedFour() {
         final Switchboard unit = Switchboard.create();
 
         unit.send(message("foo", deliveryMode()));

--- a/src/test/java/org/zalando/switchboard/contracts/UnsubscribeContract.java
+++ b/src/test/java/org/zalando/switchboard/contracts/UnsubscribeContract.java
@@ -42,7 +42,7 @@ import static org.zalando.switchboard.Timeout.within;
 public interface UnsubscribeContract<S> extends SubscriptionTrait<S>, DeliveryTrait {
 
     @Test
-    default void shouldUnsubscribe() throws TimeoutException, InterruptedException {
+    default void shouldUnsubscribe() throws TimeoutException, InterruptedException, ExecutionException {
         final Switchboard unit = Switchboard.create();
 
         // expected to unsubscribe itself in 1 ns


### PR DESCRIPTION
Possible solution for issue #8 

Also removed the generic type for Exception, the one downside to that is that `TimeoutException` now has to be handled even for the `never` case where it can never be thrown.

Open question: Is `ExecutionException` the correct wrapper or should we introduce another exception type?